### PR TITLE
feat: Enable compilation on/for `arm64` targets

### DIFF
--- a/daz/_core.c
+++ b/daz/_core.c
@@ -1,5 +1,8 @@
 #include <Python.h>
+
+#if defined(__SSE__)
 #include <xmmintrin.h>
+#endif
 
 static PyObject* set_daz(void)
 {


### PR DESCRIPTION
PR puts the inclusion of `xmmintrin.h` behind an `if defined` check to enable compiling `daz` for/on `arm64` targets